### PR TITLE
 Headerにアニメーションを実装 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bootstrap": "^5.3.3",
+        "framer-motion": "^11.6.0",
         "next": "14.2.13",
         "react": "^18",
         "react-dom": "^18",
@@ -2189,6 +2190,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.6.0.tgz",
+      "integrity": "sha512-+NJ8MpS2A7apQf3WjSrMl6xlQeYVmPGp8OZ0grNKJEyEILl6EerQrvj2bc+MgrsUndbweZsYdog1/NsxRrkWdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.3.3",
+    "framer-motion": "^11.6.0",
     "next": "14.2.13",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import PreviousFestival from "@/components/PreviousFestival/PreviousFestival";
 
 export default function Home() {
   return (
-    <div>
+    <div style={{ height: "200vh" }}>
       Hello, World!
       <PreviousFestival />
     </div>

--- a/src/components/Header/HamburgerContent/HamburgerContent.module.scss
+++ b/src/components/Header/HamburgerContent/HamburgerContent.module.scss
@@ -4,6 +4,10 @@
   padding: 1.3rem;
 }
 
+.flex {
+  display: flex;
+}
+
 @media screen and (max-width: 768px) {
   .hamburgerContent {
     display: flex;

--- a/src/components/Header/HamburgerContent/HamburgerContent.tsx
+++ b/src/components/Header/HamburgerContent/HamburgerContent.tsx
@@ -11,6 +11,12 @@ interface Props {
 export default function HamburgerContent({ open }: Props) {
   const [contentIsVisible, setContentIsVisible] = useState(false);
 
+  /*
+   * アニメーションを三段階で実装している
+   * closed : ハンバーガーメニューが閉じている
+   * open && !contentIsVisible : ハンバーガーメニューが開いている途中で、コンテンツが表示されていない
+   * open && contentIsVisible : ハンバーガーメニューが開いていて、コンテンツが表示されている
+   */
   return (
     <motion.div
       initial={{ height: 0 }}

--- a/src/components/Header/HamburgerContent/HamburgerContent.tsx
+++ b/src/components/Header/HamburgerContent/HamburgerContent.tsx
@@ -1,11 +1,35 @@
+import { motion } from "framer-motion";
+import { useState } from "react";
 import NavigationButton from "../NavigationButton/NavigationButton";
 import NavigationDropDown from "../NavigationButton/NavigationDropDown";
 import styles from "./HamburgerContent.module.scss";
 
-export default function HamburgerContent() {
+interface Props {
+  open: boolean;
+}
+
+export default function HamburgerContent({ open }: Props) {
+  const [contentIsVisible, setContentIsVisible] = useState(false);
+
   return (
-    <div>
-      <div className={`${styles.hamburgerContent}`}>
+    <motion.div
+      initial={{ height: 0 }}
+      animate={{
+        height: open ? "auto" : 0,
+      }}
+      transition={{ duration: 0.5 }}
+      onAnimationStart={() => setContentIsVisible(false)}
+      onAnimationComplete={() => setContentIsVisible(open)}
+    >
+      <motion.div
+        variants={{
+          hidden: { opacity: 0, scale: 0.98, transition: { duration: 0.13 } },
+          visible: { opacity: 1, scale: 1, transition: { duration: 0.2 } },
+        }}
+        initial="hidden"
+        animate={contentIsVisible ? "visible" : "hidden"}
+        className={`${styles.hamburgerContent} `}
+      >
         <NavigationButton text="工大祭とは" url="/about/" />
         <NavigationDropDown
           text="企画"
@@ -24,7 +48,7 @@ export default function HamburgerContent() {
         <NavigationButton text="キャラクター" url="/character/" />
         <NavigationButton text="スポンサー" url="/sponsor" />
         <NavigationButton text="FAQ" url="/faq/" />
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/src/components/Header/HamburgerIcon/HamburgerIcon.module.scss
+++ b/src/components/Header/HamburgerIcon/HamburgerIcon.module.scss
@@ -1,13 +1,13 @@
 .hamburgerIcon {
+  display: none;
   font-size: 24px;
   background: none;
   border: none;
   width: 12vw;
 }
 
-// PCの時
-@media screen and (min-width: 768px) {
+@media screen and (max-width: 768px) {
   .hamburgerIcon {
-    display: none;
+    display: block;
   }
 }

--- a/src/components/Header/HamburgerIcon/HamburgerIcon.module.scss
+++ b/src/components/Header/HamburgerIcon/HamburgerIcon.module.scss
@@ -1,13 +1,28 @@
-.hamburgerIcon {
+.hamburgerIconContainer {
   display: none;
-  font-size: 24px;
+  position: relative;
+  margin-right: 1vw;
+  width: 12vw;
+  justify-content: center;
+}
+
+.hamburgerIconButton {
+  position: absolute;
   background: none;
   border: none;
-  width: 12vw;
+  height: 36px;
+  width: 36px;
+  top: -18px;
+  z-index: 4;
+}
+
+.hamburgerIcon {
+  height: 24px;
+  width: 24px;
 }
 
 @media screen and (max-width: 768px) {
-  .hamburgerIcon {
-    display: block;
+  .hamburgerIconContainer {
+    display: flex;
   }
 }

--- a/src/components/Header/HamburgerIcon/HamburgerIcon.tsx
+++ b/src/components/Header/HamburgerIcon/HamburgerIcon.tsx
@@ -1,15 +1,71 @@
 "use client";
-import { RxHamburgerMenu } from "react-icons/rx";
 import styles from "./HamburgerIcon.module.scss";
+import { AnimationProps, motion } from "framer-motion";
+
+interface Props {
+  hamburgerMenuIsOpen: boolean;
+  toggleHamburgerMenu: () => void;
+}
+
+interface LineProps {
+  className?: string;
+  variants: AnimationProps["variants"];
+  isOpen: boolean;
+}
+const Line = ({ className, variants, isOpen }: LineProps) => {
+  return (
+    <motion.line
+      className={`${styles.line} ${className}`}
+      variants={variants}
+      initial="closed"
+      animate={isOpen ? "opened" : "closed"}
+      transition={{ duration: 0.5 }}
+      style={{ originX: "center", originY: "center" }} // CSSモジュールで当てると何故か上書きされてしまう
+      x1={0}
+      x2={24}
+      y1={12}
+      y2={12}
+      stroke={"#000"}
+      strokeWidth={1.5}
+    />
+  );
+};
+
+const rotateBaseAngle = 180;
 
 export default function HamburgerIcon({
+  hamburgerMenuIsOpen,
   toggleHamburgerMenu,
-}: {
-  toggleHamburgerMenu: () => void;
-}) {
+}: Props) {
   return (
-    <button className={`${styles.hamburgerIcon}`} onClick={toggleHamburgerMenu}>
-      <RxHamburgerMenu />
-    </button>
+    <div className={`${styles.hamburgerIconContainer}`}>
+      <button
+        className={styles.hamburgerIconButton}
+        onClick={toggleHamburgerMenu}
+      />
+      <svg className={styles.hamburgerIcon}>
+        <Line
+          isOpen={hamburgerMenuIsOpen}
+          variants={{
+            closed: { rotate: 0, translateY: -8 },
+            opened: { rotate: 45 + rotateBaseAngle, translateY: 0 },
+          }}
+        />
+        <Line
+          isOpen={hamburgerMenuIsOpen}
+          variants={{
+            closed: { opacity: 1, rotate: 0 },
+            opened: { opacity: 0, rotate: rotateBaseAngle },
+          }}
+        />
+        <Line
+          isOpen={hamburgerMenuIsOpen}
+          variants={{
+            closed: { rotate: 0, translateY: 8 },
+            opened: { rotate: -45 + rotateBaseAngle, translateY: 0 },
+          }}
+        />
+      </svg>
+    </div>
   );
 }

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,13 +1,7 @@
-.header {
-  transition: opacity 1s ease 0.3s;
-}
-
 .navigationContainer {
   opacity: 1;
-  transform: translateY(0);
   padding: 8px 0 6px 0;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.15);
-  -webkit-transition: all 0.3s ease-out;
   transition: all 0.3s ease-out;
 }
 .navigationContainer.scrollOn {
@@ -19,7 +13,7 @@
   transition: all 0.3s ease-out;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 767px) {
   .navigationContainer {
     padding: 0 !important;
   }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import NavigationButtonContainer from "./NavigationButtonContainer/NavigationBut
 import HamburgerContent from "./HamburgerContent/HamburgerContent";
 
 export default function Header() {
-  const [hamburgerMenuOpen, setHamburgerMenuOpen] = useState(false);
+  const [hamburgerMenuIsOpen, setHamburgerMenuOpen] = useState(false);
   const [headerClass, setHeaderClass] = useState("start-style");
   function toggleHamburgerMenu() {
     setHamburgerMenuOpen((prev) => !prev);
@@ -32,15 +32,18 @@ export default function Header() {
   }, []);
 
   return (
-    <header className={styles.header}>
+    <header>
       <div className={`${styles.navigationContainer} ${headerClass} bg-light`}>
         <nav
           className={`${styles.navigation} navbar navbar-expand-md navbar-light`}
         >
           <BannerImage />
-          <HamburgerIcon toggleHamburgerMenu={toggleHamburgerMenu} />
+          <HamburgerIcon
+            hamburgerMenuIsOpen={hamburgerMenuIsOpen}
+            toggleHamburgerMenu={toggleHamburgerMenu}
+          />
           <NavigationButtonContainer />
-          <HamburgerContent open={hamburgerMenuOpen} />
+          <HamburgerContent open={hamburgerMenuIsOpen} />
         </nav>
       </div>
     </header>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import BannerImage from "./BannerImage/BannerImage";
 import styles from "./Header.module.scss";
 import HamburgerIcon from "./HamburgerIcon/HamburgerIcon";
@@ -8,21 +8,39 @@ import HamburgerContent from "./HamburgerContent/HamburgerContent";
 
 export default function Header() {
   const [hamburgerMenuOpen, setHamburgerMenuOpen] = useState(false);
+  const [headerClass, setHeaderClass] = useState("start-style");
   function toggleHamburgerMenu() {
     setHamburgerMenuOpen((prev) => !prev);
   }
 
-  // TODO: styles.scrollOn を当てる
+  // スクロールイベントを追加
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollY = window.scrollY;
+      if (scrollY >= 200) {
+        setHeaderClass(styles.scrollOn);
+        console.log("scrollOn");
+      } else {
+        setHeaderClass("");
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
     <header className={styles.header}>
-      <div className={`${styles.navigationContainer} bg-light`}>
+      <div className={`${styles.navigationContainer} ${headerClass} bg-light`}>
         <nav
           className={`${styles.navigation} navbar navbar-expand-md navbar-light`}
         >
           <BannerImage />
-          <NavigationButtonContainer />
           <HamburgerIcon toggleHamburgerMenu={toggleHamburgerMenu} />
-          {hamburgerMenuOpen && <HamburgerContent />}
+          <NavigationButtonContainer />
+          <HamburgerContent open={hamburgerMenuOpen} />
         </nav>
       </div>
     </header>

--- a/src/components/Header/NavigationButton/NavigationButton.tsx
+++ b/src/components/Header/NavigationButton/NavigationButton.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import styles from "./NavigationItem.module.scss";
 
 interface NavigationButtonProps {
@@ -7,8 +8,10 @@ interface NavigationButtonProps {
 
 export default function NavigationButton(props: NavigationButtonProps) {
   return (
-    <div
+    <motion.div
       className={`${styles.navItem} ${styles.nonExpandable} nav-item non-expandable pl-4 pl-md-0`}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
     >
       <a
         className={`${styles.navLink} nav-link`}
@@ -17,6 +20,6 @@ export default function NavigationButton(props: NavigationButtonProps) {
       >
         {props.text}
       </a>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/Header/NavigationButton/NavigationDropDown.tsx
+++ b/src/components/Header/NavigationButton/NavigationDropDown.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import styles from "./NavigationItem.module.scss";
 import { useState } from "react";
 
@@ -9,17 +9,6 @@ interface NavigationDropDownProps {
     url: string;
   }[];
 }
-
-const dropdownMenuVariants = {
-  hidden: {
-    opacity: 0,
-    height: 0,
-  },
-  visible: {
-    opacity: 1,
-    height: "auto",
-  },
-};
 
 function DropdownIcon({ isOpen }: { isOpen: boolean }) {
   const lineProps = {
@@ -63,26 +52,30 @@ export default function NavigationDropDown(props: NavigationDropDownProps) {
       <a className={`${styles.navLink} nav-link`} aria-label={props.text}>
         {props.text}
       </a>
-      <motion.div
-        className={styles.dropdownMenu}
-        initial="hidden"
-        variants={dropdownMenuVariants}
-        animate={dropdownMenuIsVisible ? "visible" : "hidden"}
-        transition={{ duration: 0.5 }}
-      >
-        <div className={styles.dropdownItemContainer}>
-          {props.items.map((item) => (
-            <a
-              key={item.url}
-              className={`${styles.dropdownItem} dropdown-item`}
-              href={item.url}
-              aria-label={item.text}
-            >
-              {item.text}
-            </a>
-          ))}
-        </div>
-      </motion.div>
+      <AnimatePresence>
+        {dropdownMenuIsVisible && (
+          <motion.div
+            className={styles.dropdownMenu}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className={styles.dropdownItemsContainer}>
+              {props.items.map((item) => (
+                <a
+                  key={item.url}
+                  className={`${styles.dropdownItem} dropdown-item`}
+                  href={item.url}
+                  aria-label={item.text}
+                >
+                  {item.text}
+                </a>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/components/Header/NavigationButton/NavigationDropDown.tsx
+++ b/src/components/Header/NavigationButton/NavigationDropDown.tsx
@@ -21,6 +21,32 @@ const dropdownMenuVariants = {
   },
 };
 
+function DropdownIcon({ isOpen }: { isOpen: boolean }) {
+  const lineProps = {
+    x1: 4,
+    x2: 20,
+    y1: 12,
+    y2: 12,
+    stroke: "#000",
+    strokeWidth: 1,
+  };
+  return (
+    <svg className={styles.dropdownIcon}>
+      <motion.line {...lineProps} />
+      <motion.line
+        variants={{
+          closed: { rotate: -90, opacity: 1 },
+          opened: { rotate: 0, opacity: 0 },
+        }}
+        animate={isOpen ? "opened" : "closed"}
+        transition={{ duration: 0.3 }}
+        style={{ originX: "center", originY: "center" }}
+        {...lineProps}
+      />
+    </svg>
+  );
+}
+
 export default function NavigationDropDown(props: NavigationDropDownProps) {
   const [dropdownMenuIsVisible, setDropdownMenuIsVisible] = useState(false);
   return (
@@ -30,7 +56,10 @@ export default function NavigationDropDown(props: NavigationDropDownProps) {
       onHoverStart={() => setDropdownMenuIsVisible(true)}
       onClick={() => setDropdownMenuIsVisible(!dropdownMenuIsVisible)}
       onHoverEnd={() => setDropdownMenuIsVisible(false)}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
     >
+      <DropdownIcon isOpen={dropdownMenuIsVisible} />
       <a className={`${styles.navLink} nav-link`} aria-label={props.text}>
         {props.text}
       </a>

--- a/src/components/Header/NavigationButton/NavigationDropDown.tsx
+++ b/src/components/Header/NavigationButton/NavigationDropDown.tsx
@@ -1,4 +1,6 @@
+import { motion } from "framer-motion";
 import styles from "./NavigationItem.module.scss";
+import { useState } from "react";
 
 interface NavigationDropDownProps {
   text: string;
@@ -7,24 +9,51 @@ interface NavigationDropDownProps {
     url: string;
   }[];
 }
+
+const dropdownMenuVariants = {
+  hidden: {
+    opacity: 0,
+    height: 0,
+  },
+  visible: {
+    opacity: 1,
+    height: "auto",
+  },
+};
+
 export default function NavigationDropDown(props: NavigationDropDownProps) {
+  const [dropdownMenuIsVisible, setDropdownMenuIsVisible] = useState(false);
   return (
-    <div className={`${styles.navItem} nav-item pl-4 pl-md-0`}>
+    <motion.div
+      className={`${styles.navItem} nav-item pl-4 pl-md-0`}
+      // hover時、クリック時にドロップダウンを表示する
+      onHoverStart={() => setDropdownMenuIsVisible(true)}
+      onClick={() => setDropdownMenuIsVisible(!dropdownMenuIsVisible)}
+      onHoverEnd={() => setDropdownMenuIsVisible(false)}
+    >
       <a className={`${styles.navLink} nav-link`} aria-label={props.text}>
         {props.text}
       </a>
-      <div className={`${styles.dropdownMenu}`}>
-        {props.items.map((item) => (
-          <a
-            key={item.url}
-            className={`${styles.dropdownItem} dropdown-item`}
-            href={item.url}
-            aria-label={item.text}
-          >
-            {item.text}
-          </a>
-        ))}
-      </div>
-    </div>
+      <motion.div
+        className={styles.dropdownMenu}
+        initial="hidden"
+        variants={dropdownMenuVariants}
+        animate={dropdownMenuIsVisible ? "visible" : "hidden"}
+        transition={{ duration: 0.5 }}
+      >
+        <div className={styles.dropdownItemContainer}>
+          {props.items.map((item) => (
+            <a
+              key={item.url}
+              className={`${styles.dropdownItem} dropdown-item`}
+              href={item.url}
+              aria-label={item.text}
+            >
+              {item.text}
+            </a>
+          ))}
+        </div>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/src/components/Header/NavigationButton/NavigationItem.module.scss
+++ b/src/components/Header/NavigationButton/NavigationItem.module.scss
@@ -46,8 +46,20 @@
     margin-top: 10px !important;
     margin-bottom: 20px !important;
   }
-  .navLink {
-    padding: 0;
+}
+
+// dropdownIcon
+.dropdownIcon {
+  display: none;
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: 12px;
+  left: 1px;
+}
+@media screen and (max-width: 767px) {
+  .dropdownIcon {
+    display: block;
   }
 }
 
@@ -59,7 +71,6 @@
   color: black !important;
   position: relative;
   display: inline-block;
-  transition: all 200ms linear;
   padding: 0.5rem 0.3vw !important;
   font-size: 18px;
 }
@@ -68,6 +79,11 @@
 }
 .navItem:not(.nonExpandable) > .navLink {
   cursor: default;
+}
+@media screen and (max-width: 768px) {
+  .navLink {
+    padding: 0;
+  }
 }
 
 // dropdownMenu
@@ -79,7 +95,6 @@
 }
 @media screen and (max-width: 768px) {
   .dropdownMenu {
-    transform: translate3d(0, -10px, 0);
     background-color: var(--light);
     position: relative;
   }
@@ -87,8 +102,7 @@
 
 // dropdownItemContainer
 .dropdownItemContainer {
-  padding: 15px;
-  padding-bottom: 5px;
+  padding: 5px;
 }
 
 // dropdown-item
@@ -100,7 +114,6 @@
   font-size: 15px;
   font-weight: 600 !important;
   border-radius: 2px;
-  transition: all 200ms linear;
   line-height: 1.5;
 }
 .dropdownItem:hover {

--- a/src/components/Header/NavigationButton/NavigationItem.module.scss
+++ b/src/components/Header/NavigationButton/NavigationItem.module.scss
@@ -72,31 +72,23 @@
 
 // dropdownMenu
 .dropdownMenu {
-  transform: translate3d(0, 10px, 0);
-  opacity: 0;
-  max-height: 0;
+  padding: 0;
   display: block;
-  visibility: hidden;
-  padding: 10px !important;
   position: absolute;
   background-color: rgba(255, 255, 255, 0.9);
-  transition: all 200ms linear;
-}
-.navItem:hover .dropdownMenu {
-  opacity: 1;
-  display: block;
-  visibility: visible;
-  max-height: 999px;
-  transform: translate3d(0, 0px, 0);
 }
 @media screen and (max-width: 768px) {
   .dropdownMenu {
     transform: translate3d(0, -10px, 0);
-  }
-  .navItem:hover .dropdownMenu {
-    position: relative;
     background-color: var(--light);
+    position: relative;
   }
+}
+
+// dropdownItemContainer
+.dropdownItemContainer {
+  padding: 15px;
+  padding-bottom: 5px;
 }
 
 // dropdown-item

--- a/src/components/Header/NavigationButton/NavigationItem.module.scss
+++ b/src/components/Header/NavigationButton/NavigationItem.module.scss
@@ -88,7 +88,6 @@
 
 // dropdownMenu
 .dropdownMenu {
-  padding: 0;
   display: block;
   position: absolute;
   background-color: rgba(255, 255, 255, 0.9);
@@ -100,8 +99,7 @@
   }
 }
 
-// dropdownItemContainer
-.dropdownItemContainer {
+.dropdownItemsContainer {
   padding: 5px;
 }
 

--- a/src/components/Header/NavigationButtonContainer/NavigationButtonContainer.tsx
+++ b/src/components/Header/NavigationButtonContainer/NavigationButtonContainer.tsx
@@ -4,7 +4,7 @@ import styles from "./NavigationButtonContainer.module.scss";
 
 export default function NavigationButtonContainer() {
   return (
-    <div className={`${styles.textButtonContainer}`}>
+    <div className={`${styles.textButtonContainer} `}>
       <div className={`${styles.navbarNav} navbar-nav`}>
         <NavigationButton text="工大祭とは" url="/about/" />
         <NavigationDropDown


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ Headerにアニメーションを実装 #24 ](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/24)

## 概要
<!-- 変更内容を簡単に説明 -->
ヘッダーにアニメーションを実装し、原則61stと同じ見た目を目指す

## 変更内容
<!-- 変更の概要と説明を記述 -->
- スクロール時のヘッダーの切り離し
- ハンバーガーアイコン自体のアニメーション
- ハンバーガーアイコン押下時のハンバーガーメニューのアニメーション
- ハンバーガーメニュー内の"企画"の左にアイコン追加
- ハンバーガーメニュー内の"企画"のホバー時のアニメーション改善
- ページ読み込み時のヘッダーアニメーション

## 変更していない点
HeaderのBannerImageにfade inを実装すること

## 61stとの違い
Framer Motionを利用している事によるアニメーションの差

## 変更内容の説明
<!-- より詳細な説明や、複数ある選択肢からなぜその実装方法を選んだのか等 -->
<!-- これがあるとレビューするときに聞く手間が省けるから助かる -->
基本的にFramer Motionを用いてアニメーションを実装している。
61stでbefore, afterを用いて実装していたアイコンは、今回svgタグを用いて実装した。（Framer Motionを適用するため）

conflictの解消と、余計な差分の修正は今からやります（常にmainを最新にしろとあれほど）

## 確認方法
<!-- 必要があれば、変更の確認手順やテスト方法を記述 -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->


# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
