### PR TITLE
/aboutに飛んだ際にpre-festivalが表示されない

### DIFF
--- a/src/components/PreviousFestival/PreviousFestival.tsx
+++ b/src/components/PreviousFestival/PreviousFestival.tsx
@@ -15,47 +15,47 @@ export default function PreviousFestival() {
       <div>
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/61st"
-          thisImage="./img/61st.webp"
+          thisImage="/img/61st.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/60th"
-          thisImage="./img/60th.webp"
+          thisImage="/img/60th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/59th"
-          thisImage="./img/59th.webp"
+          thisImage="/img/59th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/58th"
-          thisImage="./img/58th.webp"
+          thisImage="/img/58th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/57th"
-          thisImage="./img/57th.webp"
+          thisImage="/img/57th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/56th"
-          thisImage="./img/56th.webp"
+          thisImage="/img/56th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/55th"
-          thisImage="./img/55th.webp"
+          thisImage="/img/55th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/54th"
-          thisImage="./img/54th.webp"
+          thisImage="/img/54th.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/53rd"
-          thisImage="./img/53rd.webp"
+          thisImage="/img/53rd.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/52nd"
-          thisImage="./img/52nd.webp"
+          thisImage="/img/52nd.webp"
         />
         <PrevFestivalCard
           thisHref="https://www.koudaisai.com/51st"
-          thisImage="./img/51st.webp"
+          thisImage="/img/51st.webp"
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [/aboutに飛んだ際にpre-festivalが表示されない #30](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/30)

## 概要
<!-- 変更内容を簡単に説明 -->
aboutのページの過去サイトのサムネイルがうまく表示されていなかったため、修正した

## 変更内容
<!-- 変更の概要と説明を記述 -->
- パスを見直し、変更
  - ./img/イメージ名　-> /img/イメージ名

## 変更内容の説明
<!-- より詳細な説明や、複数ある選択肢からなぜその実装方法を選んだのか等 -->
<!-- これがあるとレビューするときに聞く手間が省けるから助かる -->
イメージのパスの理解が浅かったため、わざわざ教えていただきありがとうございました。大変助かりました。

## 確認方法
<!-- 必要があれば、変更の確認手順やテスト方法を記述 -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
aboutのページ下部の過去サイトのサムネイルが表示されているか確認

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
