### PR TITLE
ハンバーガーメニューが非表示で存在するバグを解消

### DIFF
--- a/src/components/Header/HamburgerContent/HamburgerContent.tsx
+++ b/src/components/Header/HamburgerContent/HamburgerContent.tsx
@@ -4,28 +4,23 @@ import NavigationButton from "../NavigationButton/NavigationButton";
 import NavigationDropDown from "../NavigationButton/NavigationDropDown";
 import styles from "./HamburgerContent.module.scss";
 
-interface Props {
-  open: boolean;
-}
-
-export default function HamburgerContent({ open }: Props) {
+export default function HamburgerContent() {
   const [contentIsVisible, setContentIsVisible] = useState(false);
 
   /*
    * アニメーションを三段階で実装している
-   * closed : ハンバーガーメニューが閉じている
-   * open && !contentIsVisible : ハンバーガーメニューが開いている途中で、コンテンツが表示されていない
-   * open && contentIsVisible : ハンバーガーメニューが開いていて、コンテンツが表示されている
+   * initial = 要素がレンダリングされていない状態
+   * !contentIsVisible = ハンバーガーメニューが開いている途中で、コンテンツが表示されていない
+   * contentIsVisible = ハンバーガーメニューが開いていて、コンテンツが表示されている
    */
   return (
     <motion.div
       initial={{ height: 0 }}
-      animate={{
-        height: open ? "auto" : 0,
-      }}
+      animate={{ height: "auto" }}
+      exit={{ height: 0 }}
       transition={{ duration: 0.5 }}
       onAnimationStart={() => setContentIsVisible(false)}
-      onAnimationComplete={() => setContentIsVisible(open)}
+      onAnimationComplete={() => setContentIsVisible(true)}
     >
       <motion.div
         variants={{

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import styles from "./Header.module.scss";
 import HamburgerIcon from "./HamburgerIcon/HamburgerIcon";
 import NavigationButtonContainer from "./NavigationButtonContainer/NavigationButtonContainer";
 import HamburgerContent from "./HamburgerContent/HamburgerContent";
+import { AnimatePresence } from "framer-motion";
 
 export default function Header() {
   const [hamburgerMenuIsOpen, setHamburgerMenuOpen] = useState(false);
@@ -42,7 +43,9 @@ export default function Header() {
             toggleHamburgerMenu={toggleHamburgerMenu}
           />
           <NavigationButtonContainer />
-          <HamburgerContent open={hamburgerMenuIsOpen} />
+          <AnimatePresence>
+            {hamburgerMenuIsOpen && <HamburgerContent />}
+          </AnimatePresence>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ ハンバーガーメニューが非表示の際にメニュー内のボタンを押せてしまう問題 #52 ](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/52)

## 概要
<!-- 変更内容を簡単に説明 -->
非表示だがハンバーガーメニュー内のボタンが存在しているため、ハンバーガーメニューが閉じている際はレンダリングしないように修正
![image](https://github.com/user-attachments/assets/05f23418-e4a8-4ca7-8527-6c27a2f7ab13)


## 変更内容
<!-- 変更の概要と説明を記述 -->
- 閉じたらHamburgerメニューをレンダリングしないように変更

## 変更内容の説明
<!-- より詳細な説明や、複数ある選択肢からなぜその実装方法を選んだのか等 -->
<!-- これがあるとレビューするときに聞く手間が省けるから助かる -->


## 確認方法
<!-- 必要があれば、変更の確認手順やテスト方法を記述 -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
ハンバーガーメニューを開いたり閉じたりして、アニメーションが正常に働くことを確認

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
