### PR TITLE
企画ページのテーブルを実装

### DIFF
--- a/src/app/project/template/page.tsx
+++ b/src/app/project/template/page.tsx
@@ -7,6 +7,7 @@ import SectionBody from "@/components/Content/SectionBody/SectionBody";
 import BochureImage from "@/components/Project/BrochureImage/BochureImage";
 import ProjectLogo from "@/components/Project/ProjectLogo/ProjectLogo";
 import ProjectTag from "@/components/Project/ProjectTag/ProjectTag";
+import ProjectTable from "@/components/Project/ProjectTable/ProjectTable";
 
 export default function ProjectTemplate() {
   return (
@@ -26,6 +27,90 @@ export default function ProjectTemplate() {
           <ContentBox title={"aiueo"}>
             <ContentImage img="/img/62ndLogo.png" />
           </ContentBox>
+        </SectionBody>
+        <SectionBody>
+          <ContentTitle title="1日目" size={2} />
+          <ProjectTable>
+            <tr>
+              <th>時間</th>
+              <td>団体名</td>
+              <td>内容</td>
+            </tr>
+            <tr>
+              <th>10:15〜10:45</th>
+              <td>名古屋工業大学吹奏楽団</td>
+              <td>吹奏楽演奏</td>
+            </tr>
+            <tr>
+              <th>10:45〜10:47</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>10:47〜11:17</th>
+              <td>Prego</td>
+              <td>アカペラ</td>
+            </tr>
+            <tr>
+              <th>11:17〜11:19</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>11:19〜11:49</th>
+              <td>名城大学薬学部奇術部 ROOK</td>
+              <td>ジャグリング</td>
+            </tr>
+            <tr>
+              <th>11:49〜11:51</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>11:51〜12:11</th>
+              <td>金城学院大学ダンス部 BEAT</td>
+              <td>ダンス</td>
+            </tr>
+          </ProjectTable>
+        </SectionBody>
+        <SectionBody>
+          <ContentTitle title="2日目" size={2} />
+          <ProjectTable>
+            <tr>
+              <th>時間</th>
+              <td>団体名</td>
+              <td>内容</td>
+            </tr>
+            <tr>
+              <th>10:15〜10:40</th>
+              <td>DFC</td>
+              <td>ダンス</td>
+            </tr>
+            <tr>
+              <th>10:40〜10:42</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>10:42〜11:12</th>
+              <td>勿忘草とフィルム</td>
+              <td>アイドルコピーダンス</td>
+            </tr>
+            <tr>
+              <th>11:12〜11:14</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>11:14〜11:44</th>
+              <td>名古屋工業大学アカペラサークル Grazie!!</td>
+              <td>アカペラ演奏</td>
+            </tr>
+            <tr>
+              <th>11:44〜11:46</th>
+              <td colSpan={2}>転換</td>
+            </tr>
+            <tr>
+              <th>11:46〜12:16</th>
+              <td>NIT PACOD</td>
+              <td>ダンス</td>
+            </tr>
+          </ProjectTable>
         </SectionBody>
       </PageWrapper>
     </>

--- a/src/app/project/template/page.tsx
+++ b/src/app/project/template/page.tsx
@@ -20,6 +20,7 @@ const timeScheduleDay1 = {
     ["11:49〜11:51", "転換"],
     ["11:51〜12:11", "金城学院大学ダンス部 BEAT", "ダンス"],
   ],
+  widthWeight: [2, 5, 3],
 };
 
 const timeScheduleDay2 = {
@@ -30,6 +31,7 @@ const timeScheduleDay2 = {
     ["15:40〜15:50", "WONDER SNAKE"],
     ["15:55〜16:10", "幻"],
   ],
+  widthWeight: [1, 2],
 };
 
 export default function ProjectTemplate() {

--- a/src/app/project/template/page.tsx
+++ b/src/app/project/template/page.tsx
@@ -9,6 +9,29 @@ import ProjectLogo from "@/components/Project/ProjectLogo/ProjectLogo";
 import ProjectTag from "@/components/Project/ProjectTag/ProjectTag";
 import ProjectTable from "@/components/Project/ProjectTable/ProjectTable";
 
+const timeScheduleDay1 = {
+  column: ["時間", "団体名", "内容"],
+  data: [
+    ["10:15〜10:45", "名古屋工業大学吹奏楽団", "吹奏楽演奏"],
+    ["10:45〜10:47", "転換"],
+    ["10:47〜11:17", "Prego", "アカペラ"],
+    ["11:17〜11:19", "転換"],
+    ["11:19〜11:49", "名城大学薬学部奇術部 ROOK", "ジャグリング"],
+    ["11:49〜11:51", "転換"],
+    ["11:51〜12:11", "金城学院大学ダンス部 BEAT", "ダンス"],
+  ],
+};
+
+const timeScheduleDay2 = {
+  column: ["時間", "団体名"],
+  data: [
+    ["15:15〜15:30", "愛知flavor"],
+    ["15:30〜15:40", "Paradox Risk"],
+    ["15:40〜15:50", "WONDER SNAKE"],
+    ["15:55〜16:10", "幻"],
+  ],
+};
+
 export default function ProjectTemplate() {
   return (
     <>
@@ -30,87 +53,11 @@ export default function ProjectTemplate() {
         </SectionBody>
         <SectionBody>
           <ContentTitle title="1日目" size={2} />
-          <ProjectTable>
-            <tr>
-              <th>時間</th>
-              <td>団体名</td>
-              <td>内容</td>
-            </tr>
-            <tr>
-              <th>10:15〜10:45</th>
-              <td>名古屋工業大学吹奏楽団</td>
-              <td>吹奏楽演奏</td>
-            </tr>
-            <tr>
-              <th>10:45〜10:47</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>10:47〜11:17</th>
-              <td>Prego</td>
-              <td>アカペラ</td>
-            </tr>
-            <tr>
-              <th>11:17〜11:19</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>11:19〜11:49</th>
-              <td>名城大学薬学部奇術部 ROOK</td>
-              <td>ジャグリング</td>
-            </tr>
-            <tr>
-              <th>11:49〜11:51</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>11:51〜12:11</th>
-              <td>金城学院大学ダンス部 BEAT</td>
-              <td>ダンス</td>
-            </tr>
-          </ProjectTable>
+          <ProjectTable tableObject={timeScheduleDay1}></ProjectTable>
         </SectionBody>
         <SectionBody>
           <ContentTitle title="2日目" size={2} />
-          <ProjectTable>
-            <tr>
-              <th>時間</th>
-              <td>団体名</td>
-              <td>内容</td>
-            </tr>
-            <tr>
-              <th>10:15〜10:40</th>
-              <td>DFC</td>
-              <td>ダンス</td>
-            </tr>
-            <tr>
-              <th>10:40〜10:42</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>10:42〜11:12</th>
-              <td>勿忘草とフィルム</td>
-              <td>アイドルコピーダンス</td>
-            </tr>
-            <tr>
-              <th>11:12〜11:14</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>11:14〜11:44</th>
-              <td>名古屋工業大学アカペラサークル Grazie!!</td>
-              <td>アカペラ演奏</td>
-            </tr>
-            <tr>
-              <th>11:44〜11:46</th>
-              <td colSpan={2}>転換</td>
-            </tr>
-            <tr>
-              <th>11:46〜12:16</th>
-              <td>NIT PACOD</td>
-              <td>ダンス</td>
-            </tr>
-          </ProjectTable>
+          <ProjectTable tableObject={timeScheduleDay2}></ProjectTable>
         </SectionBody>
       </PageWrapper>
     </>

--- a/src/components/Project/ProjectTable/ProjectTable.module.scss
+++ b/src/components/Project/ProjectTable/ProjectTable.module.scss
@@ -3,57 +3,50 @@
 table.projectTable {
   width: 100%;
   margin: 1vh auto 0 auto;
+  text-align: center;
   border-collapse: collapse;
-}
-table.projectTable tr {
-  border-bottom: medium solid white;
-}
-table.projectTable tr:first-child th,
-table.projectTable tr:first-child td {
-  color: white;
-  background-color: var(--theme-color);
-}
-table.projectTable tr:first-child td {
-  border-left: thick solid white;
-}
-table.projectTable tr td:nth-child(3) {
-  border-left: medium solid white;
-}
-table.projectTable tr:first-child th:after {
-  border-left: 10px solid var(--theme-color);
-}
-table.projectTable tr:last-child {
-  border-bottom: none;
-}
-table.projectTable th {
-  position: relative;
-  padding: 10px 8px;
-  color: white;
-  text-align: left;
-  text-align: center;
-  background-color: #29c6da;
-}
-table.projectTable tr:not(:first-child) th:after {
-  position: absolute;
-  top: calc(50% - 10px);
-  right: -10px;
-  display: block;
-  width: 0px;
-  height: 0px;
-  content: "";
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  border-left: 10px solid #29c6da;
-}
-table.projectTable td {
-  min-width: 60%;
-  padding: 3px 5px 3px 13px;
-  text-align: left;
-  text-align: center;
-  background-color: #eee;
-}
-table.projectTable td span {
-  font-size: 0.95rem;
+  tr {
+    border-bottom: medium solid white;
+  }
+  th {
+    padding: 10px 8px;
+  }
+  thead th {
+    color: white;
+    background-color: var(--theme-color);
+    &:not(:first-child) {
+      border-left: medium solid white;
+    }
+  }
+  tbody {
+    --aqua: #09bdd3;
+    th {
+      position: relative;
+      color: white;
+      background-color: var(--aqua);
+      &:after {
+        position: absolute;
+        top: calc(50% - 10px);
+        right: -10px;
+        display: block;
+        width: 0px;
+        height: 0px;
+        content: "";
+        border-top: 10px solid transparent;
+        border-bottom: 10px solid transparent;
+        border-left: 10px solid var(--aqua);
+      }
+    }
+    td {
+      min-width: 60%;
+      padding: 3px 5px 3px 13px;
+      font-size: 0.95em;
+      text-align: left;
+      text-align: center;
+      background-color: #eee;
+      border-left: medium solid white;
+    }
+  }
 }
 
 @include phone {

--- a/src/components/Project/ProjectTable/ProjectTable.module.scss
+++ b/src/components/Project/ProjectTable/ProjectTable.module.scss
@@ -1,0 +1,60 @@
+@import "variables";
+
+table.projectTable {
+  width: 100%;
+  margin: 1vh auto 0 auto;
+  border-collapse: collapse;
+}
+table.projectTable tr {
+  border-bottom: medium solid white;
+}
+table.projectTable tr:first-child th,
+table.projectTable tr:first-child td {
+  color: white;
+  background-color: var(--theme-color);
+}
+table.projectTable tr:first-child td {
+  border-left: thick solid white;
+}
+table.projectTable tr td:nth-child(3) {
+  border-left: medium solid white;
+}
+table.projectTable tr:first-child th:after {
+  border-left: 10px solid var(--theme-color);
+}
+table.projectTable tr:last-child {
+  border-bottom: none;
+}
+table.projectTable th {
+  position: relative;
+  padding: 10px 8px;
+  color: white;
+  text-align: left;
+  text-align: center;
+  background-color: #29c6da;
+}
+table.projectTable tr:not(:first-child) th:after {
+  position: absolute;
+  top: calc(50% - 10px);
+  right: -10px;
+  display: block;
+  width: 0px;
+  height: 0px;
+  content: "";
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 10px solid #29c6da;
+}
+table.projectTable td {
+  min-width: 60%;
+  padding: 3px 5px 3px 13px;
+  text-align: left;
+  text-align: center;
+  background-color: #eee;
+}
+table.projectTable td span {
+  font-size: 0.95rem;
+}
+
+@include phone {
+}

--- a/src/components/Project/ProjectTable/ProjectTable.tsx
+++ b/src/components/Project/ProjectTable/ProjectTable.tsx
@@ -2,17 +2,30 @@ import React from "react";
 import styles from "./ProjectTable.module.scss";
 
 interface ProjectTableProps {
-  tableObject: { column: string[]; data: string[][] };
+  tableObject: { column: string[]; data: string[][]; widthWeight: number[] };
 }
 
 export default function ProjectTable({ tableObject }: ProjectTableProps) {
+  // 各列の幅の合計を計算
+  const totalWeight = tableObject.widthWeight.reduce(
+    (sum, weight) => sum + weight,
+    0
+  );
+
   return (
     <>
       <table className={styles.projectTable}>
         <thead>
           <tr>
             {tableObject.column.map((header, index) => (
-              <th key={index}>{header}</th>
+              <th
+                key={index}
+                style={{
+                  width: `${(tableObject.widthWeight[index] / totalWeight) * 100}%`,
+                }}
+              >
+                {header}
+              </th>
             ))}
           </tr>
         </thead>
@@ -20,15 +33,35 @@ export default function ProjectTable({ tableObject }: ProjectTableProps) {
           {tableObject.data.map((row, rowIndex) => (
             <tr key={rowIndex}>
               {/* 最初の列は th */}
-              <th>{row[0]}</th>
-              {/* データの残り部分を表示 */}
+              <th
+                style={{
+                  width: `${(tableObject.widthWeight[0] / totalWeight) * 100}%`,
+                }}
+              >
+                {row[0]}
+              </th>
+              {/* 残りの列を表示 */}
               {row.length < tableObject.column.length ? (
                 // データ数が不足している場合、残りの列数分colSpanを適用
-                <td colSpan={tableObject.column.length - 1}>{row[1]}</td>
+                <td
+                  colSpan={tableObject.column.length - 1}
+                  style={{
+                    width: `${(tableObject.widthWeight.slice(1).reduce((a, b) => a + b, 0) / totalWeight) * 100}%`,
+                  }}
+                >
+                  {row[1]}
+                </td>
               ) : (
-                row
-                  .slice(1)
-                  .map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)
+                row.slice(1).map((cell, cellIndex) => (
+                  <td
+                    key={cellIndex}
+                    style={{
+                      width: `${(tableObject.widthWeight[cellIndex + 1] / totalWeight) * 100}%`,
+                    }}
+                  >
+                    {cell}
+                  </td>
+                ))
               )}
             </tr>
           ))}

--- a/src/components/Project/ProjectTable/ProjectTable.tsx
+++ b/src/components/Project/ProjectTable/ProjectTable.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import styles from "./ProjectTable.module.scss";
+
+export default function ProjectTable({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <table className={styles.projectTable}>{children}</table>
+    </>
+  );
+}

--- a/src/components/Project/ProjectTable/ProjectTable.tsx
+++ b/src/components/Project/ProjectTable/ProjectTable.tsx
@@ -1,14 +1,39 @@
 import React from "react";
 import styles from "./ProjectTable.module.scss";
 
-export default function ProjectTable({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+interface ProjectTableProps {
+  tableObject: { column: string[]; data: string[][] };
+}
+
+export default function ProjectTable({ tableObject }: ProjectTableProps) {
   return (
     <>
-      <table className={styles.projectTable}>{children}</table>
+      <table className={styles.projectTable}>
+        <thead>
+          <tr>
+            {tableObject.column.map((header, index) => (
+              <th key={index}>{header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableObject.data.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {/* 最初の列は th */}
+              <th>{row[0]}</th>
+              {/* データの残り部分を表示 */}
+              {row.length < tableObject.column.length ? (
+                // データ数が不足している場合、残りの列数分colSpanを適用
+                <td colSpan={tableObject.column.length - 1}>{row[1]}</td>
+              ) : (
+                row
+                  .slice(1)
+                  .map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </>
   );
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [企画ページのテーブルを作成](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/84)

## 概要
<!-- 変更内容を簡単に説明 -->
企画ページのテーブルを実装
|PC|スマホ|
|-|-|
|![image](https://github.com/user-attachments/assets/11639e79-228e-48e7-92ba-42eec013f105)|![image](https://github.com/user-attachments/assets/4712c610-c3e3-4944-ac5a-24fceb82d098)|

## 変更内容
<!-- 変更の概要と説明を記述 -->
- データはオブジェクト{column, data, widthWeight}で格納するように変更
- widthWeightで各列の幅の重みを指定できるように変更

## 変更内容の説明
<!-- より詳細な説明や、複数ある選択肢からなぜその実装方法を選んだのか等 -->
<!-- これがあるとレビューするときに聞く手間が省けるから助かる -->
- 列が足りない場合(転換とか)は残りの列いっぱいに広がる

## 確認方法
<!-- 必要があれば、変更の確認手順やテスト方法を記述 -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->


# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
