### PR TITLE
headerのアニメーションが二段階になる問題を修正

### DIFF
--- a/src/components/Header/BannerImage/BannerImage.module.scss
+++ b/src/components/Header/BannerImage/BannerImage.module.scss
@@ -1,8 +1,5 @@
 @import "variables";
 
-.bannerLink {
-  width: 45vw;
-}
 .banner {
   display: inline;
   width: 100%;

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -14,7 +14,7 @@
 
 .headerMain {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-evenly;
 }
 
 .navigationContainer {

--- a/src/components/Header/NavigationButtonContainer/NavigationButtonContainer.module.scss
+++ b/src/components/Header/NavigationButtonContainer/NavigationButtonContainer.module.scss
@@ -3,6 +3,7 @@
 .navigationButtonList {
   display: flex;
   align-items: center;
+  padding: 0 10px;
   line-height: 1;
 
   @include phone {


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [スクロール時のヘッダーアニメーションが2段階で動作している](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/97)

## 概要
<!-- 変更内容を簡単に説明 -->
画面サイズによってアニメーションが2段階に見える問題を修正
アニメーション時のバナーとテキストが移動する方向を修正

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- header画像のwidthを消して無駄な余白を削除
- `display: flex;`でbannerと文字の位置を調節

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
ヘッダーのデザインを通常時とスクロール時で確認

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
