### PR TITLE
fixupコミットが残っている場合はmergeできないようにCIを設定

### DIFF
--- a/.github/workflows/block-merging-fixup-commits.yml
+++ b/.github/workflows/block-merging-fixup-commits.yml
@@ -1,0 +1,11 @@
+name: Block merging fixup commits
+
+on: [pull_request]
+
+jobs:
+  block-merging-fixup-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Block merging fixup commits
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [fixupコミットが残っている場合はmergeをブロックする](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/133)

## 概要
<!-- 変更内容を簡単に説明 -->
- fixupコミットが残っている場合はCIが落ちてmainへのmergeがブロックされる機能を追加

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
- fixupを作成してpush
- CIが落ちてmergeができないことを確認

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
