### PR TITLE
企画タグのday2が表示されない問題を修正

### DIFF
--- a/src/components/Project/ProjectTag/ProjectTag.tsx
+++ b/src/components/Project/ProjectTag/ProjectTag.tsx
@@ -21,7 +21,7 @@ export default function ProjectTag({
           ) : day1 ? (
             <span className={styles.projectDay1Tag}>1日目</span>
           ) : (
-            <span className={styles.day2}>2日目</span>
+            <span className={styles.projectDay2Tag}>2日目</span>
           )}
           {exclusiveText.map((text, index) => (
             <span key={index} className={styles.projectExclusiveTag}>


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [企画が2日目だけ開催の時に、企画タグの「day2」が表示されない](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/154)

## 概要
<!-- 変更内容を簡単に説明 -->
企画タグのday2が表示されない問題を修正

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
day2だけcss.moduleが間違ってた

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [x] PCで見た時に表示が崩れていないことを確認した
  - [x] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
