### PR TITLE
企画オブジェクトにSwiperとおすすめ機能用のオプションを追加

### DIFF
--- a/src/components/Project/ProjectTag/ProjectTag.tsx
+++ b/src/components/Project/ProjectTag/ProjectTag.tsx
@@ -20,9 +20,12 @@ export default function ProjectTag({
             <span className={styles.projectBothTag}>1・2日目</span>
           ) : day1 ? (
             <span className={styles.projectDay1Tag}>1日目</span>
-          ) : (
+          ) : day2 ? (
             <span className={styles.projectDay2Tag}>2日目</span>
+          ) : (
+            <></>
           )}
+
           {exclusiveText.map((text, index) => (
             <span key={index} className={styles.projectExclusiveTag}>
               {text}

--- a/src/components/Swiper/CustomSwiper.tsx
+++ b/src/components/Swiper/CustomSwiper.tsx
@@ -12,6 +12,7 @@ import SwiperNext from "./SwiperButtons/SwiperNext";
 import SwiperPrev from "./SwiperButtons/SwiperPrev";
 import ContentTitle from "../Content/ContentTitle/ContentTitle";
 import { templateProject } from "@/app/project/template/templateProject";
+import { convertProjectDataToSwiperCardProps } from "@/utils/converter";
 
 const projects = [
   templateProject,
@@ -57,14 +58,7 @@ export default function CustomSwiper({ title }: { title: string }) {
 
         {projects.map((project, index) => (
           <SwiperSlide key={index}>
-            <SwiperCard
-              href={`/project/${project.link}/`}
-              url={`/62nd/project/${project.link}/brochure.webp`}
-              alt={project.name}
-              projectTag={project.tags}
-              schedule={project.schedule}
-              place={project.place}
-            />
+            <SwiperCard {...convertProjectDataToSwiperCardProps(project)} />
           </SwiperSlide>
         ))}
 

--- a/src/components/Swiper/SwiperCard/SwiperCard.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperCard.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useEffect } from "react";
 import SwiperInfo from "./SwiperInfo/SwiperInfo";
 
 export interface SwiperCardProps {
+  title: string;
   href?: string;
   imageUrl: string;
   imageAlt?: string;
@@ -25,6 +26,7 @@ function getImageAspectRatio(url: string): Promise<number> {
 }
 
 export default function SwiperCard({
+  title,
   href,
   imageUrl,
   imageAlt,
@@ -55,6 +57,7 @@ export default function SwiperCard({
       <div className={styles.swiperSlideDetail}>
         <SwiperProjectTag day1 day2 projectTag={projectTag} />
         <SwiperInfo
+          title={title}
           place={place}
           schedule={schedule}
           swiperNameHoveredClassName={styles.swiperNameHovered}

--- a/src/components/Swiper/SwiperCard/SwiperCard.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperCard.tsx
@@ -1,21 +1,17 @@
 import styles from "./SwiperCard.module.scss";
 import SwiperProjectTag from "./SwiperProjectTag/SwiperProjectTag";
-import React, { useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import SwiperInfo from "./SwiperInfo/SwiperInfo";
-import { Period, Schedule } from "@/types/types";
 
-interface Time {
-  date: string;
-  time: Period;
-}
-
-interface SwiperCardProps {
+export interface SwiperCardProps {
   href?: string;
-  url: string;
-  alt?: string;
-  schedule: Schedule;
+  imageUrl: string;
+  imageAlt?: string;
+  day1?: boolean;
+  day2?: boolean;
   projectTag?: string[];
   place?: string;
+  schedule: ReactNode;
 }
 
 function getImageAspectRatio(url: string): Promise<number> {
@@ -30,11 +26,11 @@ function getImageAspectRatio(url: string): Promise<number> {
 
 export default function SwiperCard({
   href,
-  url,
-  alt,
-  schedule,
+  imageUrl,
+  imageAlt,
   projectTag,
   place,
+  schedule,
 }: SwiperCardProps) {
   // 画像が縦長か横長かによってスタイルを変更
   const [cardClassName, setCardClassName] = React.useState<string>(
@@ -42,7 +38,7 @@ export default function SwiperCard({
   );
   useEffect(() => {
     const setCardClassNameByRatio = async () => {
-      const aspectRatio = await getImageAspectRatio(url);
+      const aspectRatio = await getImageAspectRatio(imageUrl);
       setCardClassName(
         aspectRatio > 1
           ? styles.swiperCardVertical
@@ -51,22 +47,16 @@ export default function SwiperCard({
     };
     setCardClassNameByRatio();
   }, []);
-  // 処理を楽にするため、day1, day2を配列にまとめる
-  // 例: day1="1日目", day2="2日目" -> days=["1日目", "2日目"]
-  // 例: day1=undefined, day2="2日目" -> days=["2日目"]
-  const days: Time[] = [];
-  if (schedule.day1) days.push({ date: "1日目", time: schedule.day1 });
-  if (schedule.day2) days.push({ date: "2日目", time: schedule.day2 });
 
   return (
     <a className={`${styles.swiperCardContainer} ${cardClassName}`} href={href}>
-      <img src={url} alt={alt} />
+      <img src={imageUrl} alt={imageAlt} />
       <div className={styles.swiperSlideMask} />
       <div className={styles.swiperSlideDetail}>
-        <SwiperProjectTag schedule={schedule} projectTag={projectTag} />
+        <SwiperProjectTag day1 day2 projectTag={projectTag} />
         <SwiperInfo
           place={place}
-          days={days}
+          schedule={schedule}
           swiperNameHoveredClassName={styles.swiperNameHovered}
           swiperArrowHoveredClassName={styles.swiperArrowHovered}
         />

--- a/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfo.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfo.tsx
@@ -8,13 +8,15 @@ import SwiperInfoContent from "./SwiperInfoContent";
 // スライドがホバーされたときのCSSはSwiperCard.module.scssで定義
 // クラス名を受け取ってスタイルを変更する
 interface SwiperInfoProps {
+  title: string;
   place?: string;
-  schedule: ReactNode;
+  schedule?: ReactNode;
   swiperNameHoveredClassName: string;
   swiperArrowHoveredClassName: string;
 }
 
 export default function SwiperInfo({
+  title,
   place,
   schedule,
   swiperNameHoveredClassName,
@@ -24,7 +26,7 @@ export default function SwiperInfo({
     <>
       {/* スライドタイトル */}
       <span className={`${styles.swiperName} ${swiperNameHoveredClassName}`}>
-        企画一覧
+        {title}
         <ImArrowUpRight2
           className={`${styles.swiperArrow} ${swiperArrowHoveredClassName}`}
         />
@@ -33,7 +35,9 @@ export default function SwiperInfo({
       {/* Place */}
       {place && <SwiperInfoContent icon={FiMapPin} content={[place]} />}
       {/* Date */}
-      <SwiperInfoContent icon={FaRegCalendarAlt} content={schedule} />
+      {schedule && (
+        <SwiperInfoContent icon={FaRegCalendarAlt} content={schedule} />
+      )}
     </>
   );
 }

--- a/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfo.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfo.tsx
@@ -1,25 +1,22 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { FaRegCalendarAlt } from "react-icons/fa";
 import { FiMapPin } from "react-icons/fi";
 import { ImArrowUpRight2 } from "react-icons/im";
-import { LuClock } from "react-icons/lu";
 import styles from "./SwiperInfo.module.scss";
 import SwiperInfoContent from "./SwiperInfoContent";
-import { Period } from "@/types/types";
-import { formatPeriod } from "@/utils/formatter";
 
 // スライドがホバーされたときのCSSはSwiperCard.module.scssで定義
 // クラス名を受け取ってスタイルを変更する
 interface SwiperInfoProps {
   place?: string;
-  days: { date: string; time: Period }[];
+  schedule: ReactNode;
   swiperNameHoveredClassName: string;
   swiperArrowHoveredClassName: string;
 }
 
 export default function SwiperInfo({
   place,
-  days,
+  schedule,
   swiperNameHoveredClassName,
   swiperArrowHoveredClassName,
 }: SwiperInfoProps) {
@@ -36,24 +33,7 @@ export default function SwiperInfo({
       {/* Place */}
       {place && <SwiperInfoContent icon={FiMapPin} content={[place]} />}
       {/* Date */}
-      {days.length === 1 && (
-        <SwiperInfoContent icon={FaRegCalendarAlt} content={[days[0].date]} />
-      )}
-      {/* Time */}
-      {days.length === 1 && (
-        <SwiperInfoContent
-          icon={LuClock}
-          content={[formatPeriod(days[0].time)]}
-        />
-      )}
-      {days.length === 2 && (
-        <SwiperInfoContent
-          icon={FaRegCalendarAlt}
-          content={days.map(
-            (schedule) => `${schedule.date}: ${formatPeriod(schedule.time)}`
-          )}
-        />
-      )}
+      <SwiperInfoContent icon={FaRegCalendarAlt} content={schedule} />
     </>
   );
 }

--- a/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfoContent.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperInfo/SwiperInfoContent.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import styles from "./SwiperInfo.module.scss";
 import { IconType } from "react-icons";
 
 interface SwiperInfoContentProps {
   icon: IconType;
-  content: string[];
+  content: string | ReactNode;
 }
 
 export default function SwiperInfoContent({
@@ -14,14 +14,7 @@ export default function SwiperInfoContent({
   return (
     <p className={styles.swiperInfoWrapper}>
       <Icon />
-      <span className={styles.swiperInfo}>
-        {content.map((text, index) => (
-          <React.Fragment key={index}>
-            {text}
-            <br />
-          </React.Fragment>
-        ))}
-      </span>
+      <span className={styles.swiperInfo}>{content}</span>
     </p>
   );
 }

--- a/src/components/Swiper/SwiperCard/SwiperProjectTag/SwiperProjectTag.tsx
+++ b/src/components/Swiper/SwiperCard/SwiperProjectTag/SwiperProjectTag.tsx
@@ -1,24 +1,25 @@
-import { Schedule } from "@/types/types";
 import styles from "./SwiperProjectTag.module.scss";
 
 interface SwiperProjectTagProps {
-  schedule: Schedule;
+  day1?: boolean;
+  day2?: boolean;
   projectTag?: string[];
 }
 
 export default function SwiperProjectTag({
-  schedule,
+  day1,
+  day2,
   projectTag,
 }: SwiperProjectTagProps) {
   let date: string | undefined;
   let dateTagClassName: string | undefined;
-  if (schedule.day1 && schedule.day2) {
+  if (day1 && day2) {
     date = "1・2日目";
     dateTagClassName = styles.swiperDayBothTag;
-  } else if (schedule.day1) {
+  } else if (day1) {
     date = "1日目";
     dateTagClassName = styles.swiperDay1Tag;
-  } else if (schedule.day2) {
+  } else if (day2) {
     date = "2日目";
     dateTagClassName = styles.swiperDay2Tag;
   }

--- a/src/types/projectInterface.ts
+++ b/src/types/projectInterface.ts
@@ -21,4 +21,22 @@ export interface ProjectData {
 
   // 任意のデータ(こちらも企画ページにしか表示しない)
   projectBoxList: ProjectBox[];
+
+  // オプション
+  swiperOption?: {
+    title?: string;
+    dayTag?: {
+      day1?: boolean;
+      day2?: boolean;
+    };
+    projectTag?: string[];
+    place?: string;
+    schedule?: {
+      day1?: string;
+      day2?: string;
+    };
+  };
+  recommendOption?: {
+    schedule?: Schedule;
+  };
 }

--- a/src/utils/converter.tsx
+++ b/src/utils/converter.tsx
@@ -1,4 +1,6 @@
+import { SwiperCardProps } from "@/components/Swiper/SwiperCard/SwiperCard";
 import { NITFES_DATE_TEXT } from "@/const/const";
+import { ProjectData } from "@/types/projectInterface";
 import { Schedule } from "@/types/types";
 import { formatPeriod } from "@/utils/formatter";
 import React from "react";
@@ -23,4 +25,39 @@ export const convertScheduleToReactNode = (schedule: Schedule): ReactNode => {
       )}
     </>
   );
+};
+
+export const convertScheduleToSummaryReactNode = (
+  schedule: Schedule
+): ReactNode => {
+  return (
+    <>
+      {schedule.day1 && (
+        <>
+          {NITFES_DATE_TEXT.DAY1}: {formatPeriod(schedule.day1)}
+          <br />
+        </>
+      )}
+      {schedule.day2 && (
+        <>
+          {NITFES_DATE_TEXT.DAY2}: {formatPeriod(schedule.day2)}
+          <br />
+        </>
+      )}
+    </>
+  );
+};
+export const convertProjectDataToSwiperCardProps = (
+  project: ProjectData
+): SwiperCardProps => {
+  const props: SwiperCardProps = {
+    href: `/project/${project.link}/`,
+    imageUrl: `/62nd/project/${project.link}/brochure.webp`,
+    imageAlt: project.name,
+    projectTag: project.tags,
+    schedule: convertScheduleToSummaryReactNode(project.schedule),
+    place: project.place,
+  };
+
+  return props;
 };

--- a/src/utils/converter.tsx
+++ b/src/utils/converter.tsx
@@ -47,10 +47,12 @@ export const convertScheduleToSummaryReactNode = (
     </>
   );
 };
+
 export const convertProjectDataToSwiperCardProps = (
   project: ProjectData
 ): SwiperCardProps => {
   const props: SwiperCardProps = {
+    title: project.name,
     href: `/project/${project.link}/`,
     imageUrl: `/62nd/project/${project.link}/brochure.webp`,
     imageAlt: project.name,
@@ -58,6 +60,42 @@ export const convertProjectDataToSwiperCardProps = (
     schedule: convertScheduleToSummaryReactNode(project.schedule),
     place: project.place,
   };
+
+  if (!project.swiperOption) return props; // オプションがなければそのまま返す
+
+  // オプションがある場合は上書き
+  const {
+    title,
+    dayTag,
+    projectTag: swiperProjectTag,
+    place,
+    schedule,
+  } = project.swiperOption;
+
+  if (title) props.title = title;
+  if (dayTag) {
+    props.day1 = dayTag.day1;
+    props.day2 = dayTag.day2;
+  }
+  if (swiperProjectTag) props.projectTag = swiperProjectTag;
+  if (place) props.place = place;
+  if (schedule) {
+    props.schedule = (
+      <span>
+        {schedule.day1 && (
+          <>
+            {NITFES_DATE_TEXT.DAY1}: {schedule.day1}
+            <br />
+          </>
+        )}
+        {schedule.day2 && (
+          <>
+            {NITFES_DATE_TEXT.DAY2}: {schedule.day2}
+          </>
+        )}
+      </span>
+    );
+  }
 
   return props;
 };


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ 企画ページ, Swiper, おすすめ表示で別々のデータを参照できるように変更 #165 ](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/165)
Closes [ Scheduleを指定しない場合day2タグが表示されない #181 ](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/181)

## 概要
<!-- 変更内容を簡単に説明 -->
企画ページとSwiperで表示する内容を分けたい場合があるため、Swiperに渡す内容をオプションとして上書きできるよう、企画オブジェクトを修正した。

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- Swiperに引数（企画オブジェクト）を渡す方法を変更（リファクタ）
- Swiperオプションを実装
- Recommendedオプションもついでに実装

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
http://localhost:3000/project/template

変更を確認

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
