### PR TITLE
Projectコンポーネントでビラとロゴのパスが指定されている場合は正しく反映されるように修正

### DIFF
--- a/src/components/Project/Project/Project.tsx
+++ b/src/components/Project/Project/Project.tsx
@@ -18,20 +18,28 @@ interface ProjectProps {
 
 export default function Project({
   projectData,
-  children,
+  logoPath,
+  brochurePath,
   projectTitleSize = 1,
+  children,
 }: ProjectProps) {
   return (
     <>
       <ContentTitle title={projectData.name} size={projectTitleSize} bigTitle />
       <ProjectLogo
-        img={`/62nd/project/${projectData.link}/logo.webp`}
+        img={
+          logoPath ? logoPath : `/62nd/project/${projectData.link}/logo.webp`
+        }
         alt="Logo"
       />
       <PageWrapper>
         <SectionBody>
           <BochureImage
-            img={`/62nd/project/${projectData.link}/brochure.webp`}
+            img={
+              brochurePath
+                ? brochurePath
+                : `/62nd/project/${projectData.link}/brochure.webp`
+            }
             alt="Brochure"
           />
         </SectionBody>


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [企画のロゴとビラのパスが指定されている時に正しく反映されるように修正](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/184)

## 概要
<!-- 変更内容を簡単に説明 -->
Projectコンポーネントのpropsでビラとロゴのパスを指定できるようにしていたが、その変数を使っていなかった

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
適当にパスを指定したらそのパスの画像を探すようになった

# チェックリスト
- [x] File Changedで不要な変更や誤った変更が無いか確認した
- [x] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [x] レビューを頼んだ人にDiscordでお願いした
- [x] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
