### PR TITLE
企画ページでcontentBoxの左右の位置を指定できるように変更

### DIFF
--- a/src/app/project/template/page.tsx
+++ b/src/app/project/template/page.tsx
@@ -19,7 +19,7 @@ export default function TemplateProject() {
   return (
     <>
       <Project projectData={templateProject}></Project>
-      <ContentTitle title="チケット" size={2} bigTitle />
+      <ContentTitle title="hogefuga" size={2} bigTitle />
       <PageWrapper>
         <SectionBody>
           <ContentTitle title="1日目" size={2} />

--- a/src/app/project/template/templateProject.tsx
+++ b/src/app/project/template/templateProject.tsx
@@ -26,8 +26,8 @@ const schedule = {
     }),
     endDate: createDate({
       date: 2,
-      hour: 16,
-      minute: 0,
+      hour: 15,
+      minute: 30,
     }),
   },
 };
@@ -115,6 +115,7 @@ export const templateProject: ProjectData = {
     {
       title: "ほげ",
       content: "ほげ",
+      position: "left",
     },
   ],
 };

--- a/src/components/Project/Project/Project.tsx
+++ b/src/components/Project/Project/Project.tsx
@@ -40,15 +40,24 @@ export default function Project({
               alt="Brochure"
             />
           )}
+          <ProjectContent
+            projectBoxList={projectData.projectBoxList.filter(
+              (box) => box.position === "left" // positionにleftが指定されているもののみ
+            )}
+          />
         </SectionBody>
         <SectionBody>
-          <ContentTitle title="hoge" size={2} />
+          <ContentTitle title="企画詳細" size={2} />
           <ProjectTag
             day1={projectData.schedule.day1 ? true : false}
             day2={projectData.schedule.day2 ? true : false}
             exclusiveText={projectData.tags ? projectData.tags : []}
           />
-          <ProjectContent projectBoxList={projectData.projectBoxList} />
+          <ProjectContent
+            projectBoxList={projectData.projectBoxList.filter(
+              (box) => !box.position || box.position === "right" // positionを指定していないか、rightが指定されているもののみ
+            )}
+          />
         </SectionBody>
         {children}
       </PageWrapper>

--- a/src/types/projectInterface.ts
+++ b/src/types/projectInterface.ts
@@ -5,6 +5,7 @@ import { CategoryType, Schedule } from "./types";
 export interface ProjectBox {
   title: string;
   content: string | ReactNode;
+  position?: "left" | "right";
 }
 
 export interface ProjectData {


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [企画ページでcontentBoxの左右の配置を指定できるようにしたい](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/200)

## 概要
<!-- 変更内容を簡単に説明 -->
企画ページでcontentBoxの左右の位置を指定できるように変更
![image](https://github.com/user-attachments/assets/2adea818-0226-459b-b0f1-fde4d282ad08)

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- projectBoxのinterfaceに`position?: "left" | "right";`を追加
- leftを指定した場合は左側に、rightを指定 or 未指定の場合は右側に表示

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
hogeのprojectBoxにだけ`position: "left"`を指定した
http://localhost:3000/project/template/

# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
