### PR TITLE
複数列を含むProjectTableを修正

### DIFF
--- a/src/components/Project/ProjectTable/ProjectTable.tsx
+++ b/src/components/Project/ProjectTable/ProjectTable.tsx
@@ -42,15 +42,27 @@ export default function ProjectTable({ tableObject }: ProjectTableProps) {
               </th>
               {/* 残りの列を表示 */}
               {row.length < tableObject.column.length ? (
-                // データ数が不足している場合、残りの列数分colSpanを適用
-                <td
-                  colSpan={tableObject.column.length - 1}
-                  style={{
-                    width: `${(tableObject.widthWeight.slice(1).reduce((a, b) => a + b, 0) / totalWeight) * 100}%`,
-                  }}
-                >
-                  {row[1]}
-                </td>
+                // データが不足している場合、最後の要素を引き伸ばす
+                <>
+                  {row.slice(1, -1).map((cell, cellIndex) => (
+                    <td
+                      key={cellIndex}
+                      style={{
+                        width: `${(tableObject.widthWeight[cellIndex + 1] / totalWeight) * 100}%`,
+                      }}
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                  <td
+                    colSpan={tableObject.column.length - row.length + 1}
+                    style={{
+                      width: `${(tableObject.widthWeight.slice(row.length - 1).reduce((a, b) => a + b, 0) / totalWeight) * 100}%`,
+                    }}
+                  >
+                    {row[row.length - 1]}
+                  </td>
+                </>
               ) : (
                 row.slice(1).map((cell, cellIndex) => (
                   <td


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ProjectTableの列数がバラバラの場合に表示がうまくいってない](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/226)

## 概要
<!-- 変更内容を簡単に説明 -->
次のような列数がバラバラの場合の表示がうまくいってない
```js
export const guest2 = {
  column: ["場所", "企画名", "団体名", "備考"],
  data: [
    ["5225", "「#nitechphoto」写真展＆撮影会＆活動記録", "写真サークル"],
    ["5226", "Nitech 模型展示会", "模型同好会"],
    ["5227", "名工大V（バーチャル）水泳～序章～", "水泳部", "2日目のみ"],
    ["5231", "League NitPoke 2024", "ポケモンサークルNitPoke"],
    ["5232", "マジックショー", "マジックサークルNIT"],
    ["5233", "体育会系自動車部 運転シミュレーター＆車", "自動車部"],
    [
      "52号館南口",
      "名古屋工業大学フォーミュラプロジェクト EV 車両 N.I.T-22 の展示",
      "フォーミュラプロジェクト",
    ],
    ["2311", "アカペラ教室ライブ", "アカペラサークルGrazie!"],
  ],
  widthWeight: [1, 4, 3, 2],
};
```
|actual|expected|
|-|-|
|![Image](https://github.com/user-attachments/assets/d4ca38d9-0dff-447f-9af6-d11abcdbb1d8)|![Image](https://github.com/user-attachments/assets/018e563a-2576-44be-90e3-8da89f757f01)|

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- 最後の要素のときだけ残りの列数を判定するように変更

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
`text/201-gakuseiboshu`で確認しました

# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
