### PR TITLE
過去のページの画像がsafariで見切れる問題を修正

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,7 +38,7 @@ export default function About() {
           </ContentBox>
           <ContentBox title={"来場予約や整理券は必要ですか?"}>
             <p>
-              今年から<Underline>来場予約は不要です!</Underline>
+              <Underline>来場予約は不要です!</Underline>
               是非ご来場ください!
               <br />
               また、<Underline>一部企画は整理券が必要です。</Underline>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,7 @@ export default function Top() {
           </ContentBox>
           <ContentBox title={"来場予約や整理券は必要ですか?"}>
             <p>
-              今年から<Underline>来場予約は不要です!</Underline>
+              <Underline>来場予約は不要です!</Underline>
               是非ご来場ください!
               <br />
               また、<Underline>一部企画は整理券が必要です。</Underline>

--- a/src/components/PreviousFestival/PreviousFestival.module.scss
+++ b/src/components/PreviousFestival/PreviousFestival.module.scss
@@ -45,5 +45,6 @@
 .preFestivalThum img {
   width: auto;
   height: 100%;
+  -webkit-object-fit: contain;
   object-fit: contain;
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [過去の工大祭の画像が見切れてる](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/248)

## 概要
<!-- 変更内容を簡単に説明 -->
確認中

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- 変更1
  - 説明が必要なら記述
- 変更2

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
