### PR TITLE
overflow関連の修正

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -19,9 +19,9 @@ export default function Loader() {
   // ローダー再生中はスクロール無効化
   useLayoutEffect(() => {
     if (isAnimatiomCompleted) {
-      document.documentElement.style.overflow = "auto";
+      document.documentElement.style.overflowY = "auto";
     } else {
-      document.documentElement.style.overflow = "hidden";
+      document.documentElement.style.overflowY = "hidden";
     }
   }, [isAnimatiomCompleted]);
 

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -21,9 +21,6 @@
 html {
   overflow-x: hidden;
 }
-html {
-  overflow-x: hidden;
-}
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ロード画面でoverflow-xがautoに上書きされてる](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/254)

## 概要
<!-- 変更内容を簡単に説明 -->
`html{ overflow-x: hidden }`がローダーで上書きされていた


## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- ローダーでスクロールできないようにするのを`overflow: hidden`から`overflow-y: hidden`に変更
- cssの重複している行を修正

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
