### PR TITLE
preFestivalThumのサイズ修正

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,7 +38,7 @@ export default function About() {
           </ContentBox>
           <ContentBox title={"来場予約や整理券は必要ですか?"}>
             <p>
-              今年から<Underline>来場予約は不要です!</Underline>
+              <Underline>来場予約は不要です!</Underline>
               是非ご来場ください!
               <br />
               また、<Underline>一部企画は整理券が必要です。</Underline>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,7 +91,7 @@ export default function Top() {
           </ContentBox>
           <ContentBox title={"来場予約や整理券は必要ですか?"}>
             <p>
-              今年から<Underline>来場予約は不要です!</Underline>
+              <Underline>来場予約は不要です!</Underline>
               是非ご来場ください!
               <br />
               また、<Underline>一部企画は整理券が必要です。</Underline>

--- a/src/components/PreviousFestival/PrevFestivalCard.tsx
+++ b/src/components/PreviousFestival/PrevFestivalCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./PreviousFestival.module.scss";
-import Image from "next/image";
 
 interface SiteData {
   thisHref: string;
@@ -16,13 +15,7 @@ const PrevFestivalCard: React.FC<SiteData> = ({ thisHref, thisImage }) => {
       rel="noopener noreferrer"
       aria-label="第51回工大祭のWebページを開く"
     >
-      <Image
-        src={thisImage}
-        alt="工大祭の画像"
-        width={150}
-        height={150}
-        style={{ objectFit: "contain" }}
-      />
+      <img src={thisImage} alt="工大祭の画像" />
     </a>
   );
 };

--- a/src/components/PreviousFestival/PreviousFestival.module.scss
+++ b/src/components/PreviousFestival/PreviousFestival.module.scss
@@ -31,13 +31,11 @@
   width: auto;
   height: 60px;
   margin: 5px;
-  overflow: hidden;
   background-color: white;
   border: thin solid black;
   border-radius: 5px;
   @include phone {
-    height: 13vw;
-    max-height: 7vh;
+    height: 6vh;
     margin: 3px;
   }
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [ヘッダーのハンバーガーメニューがはみ出る](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/220)

## 概要
<!-- 変更内容を簡単に説明 -->
過去のページのロゴが見切れる問題を修正
Imageをimgに変更し、width, heightの直接指定を削除


## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
どうやらSafariではcssよりもHTMLで直接指定した方を優先するみたい
おそらくcss -> htmlのレンダリング順になっているためだと予想
全く関係ないcssを少しいじるだけでも直ってたらしいので、おそらくcssだけ再レンダリングが走ると直る的な
|brefore|after|
|-|-|
|![image](https://github.com/user-attachments/assets/8dbb2760-eb39-4ae3-81f6-9aa8f4143500)|![image](https://github.com/user-attachments/assets/5707b9a7-013c-426c-a83a-962100b0b325)|

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
