### PR TITLE
Content系のコンポーネントのpropsにclassNameを追加する

### DIFF
--- a/src/app/project/zip-fm/page.module.scss
+++ b/src/app/project/zip-fm/page.module.scss
@@ -1,0 +1,8 @@
+@import "variables";
+
+.zipFMSectionBody {
+  width: 32%;
+  @include phone {
+    width: 100%;
+  }
+}

--- a/src/app/project/zip-fm/page.tsx
+++ b/src/app/project/zip-fm/page.tsx
@@ -7,6 +7,7 @@ import ContentTitle from "@/components/Content/ContentTitle/ContentTitle";
 import ContentBox from "@/components/Content/ContentBox/ContentBox";
 import ContentImage from "@/components/Content/ContentImage/ContentImage";
 import SectionBody from "@/components/Content/SectionBody/SectionBody";
+import styles from "./page.module.scss";
 
 export const metadata = {
   title: `${projectData.name} - 第${NITFES_EDITION}回工大祭`,
@@ -19,7 +20,8 @@ export default function ZipFM() {
     <Project projectData={projectData} logoPath={""} brochurePath={""}>
       <ContentTitle title={"ナビゲーター紹介"} size={2} bigTitle />
       <PageWrapper>
-        <SectionBody>
+        {/* ナビゲーター3人を横に並べるためにwidthを変更 */}
+        <SectionBody className={styles.zipFMSectionBody}>
           <ContentBox title={"Hillary"}>
             <ContentImage
               img={"/62nd/project/zip-fm/Hillary.webp"}
@@ -40,7 +42,7 @@ export default function ZipFM() {
             </ul>
           </ContentBox>
         </SectionBody>
-        <SectionBody>
+        <SectionBody className={styles.zipFMSectionBody}>
           <ContentBox title={"まるり"}>
             <ContentImage
               img={"/62nd/project/zip-fm/Maruri.webp"}
@@ -62,7 +64,7 @@ export default function ZipFM() {
             </ul>
           </ContentBox>
         </SectionBody>
-        <SectionBody>
+        <SectionBody className={styles.zipFMSectionBody}>
           <ContentBox title={"中川大輔"}>
             <ContentImage
               img={"/62nd/project/zip-fm/Nakagawa.webp"}

--- a/src/components/Content/ContentBox/ContentBox.tsx
+++ b/src/components/Content/ContentBox/ContentBox.tsx
@@ -7,6 +7,7 @@ interface ContentBoxProps {
   title: React.ReactNode;
   children: React.ReactNode;
   style?: React.CSSProperties;
+  className?: string;
   animation?: AnimationType;
 }
 
@@ -14,12 +15,13 @@ export default function ContentBox({
   title,
   children,
   style,
+  className,
   animation = "center",
   ...configs
 }: ContentBoxProps & AnimationConfigs) {
   return (
     <Animation animationType={animation} {...configs}>
-      <div className={styles.contentBox} style={style}>
+      <div className={`${styles.contentBox} ${className}`} style={style}>
         <span className={styles.contentBoxTitle}>{title}</span>
         {children}
       </div>

--- a/src/components/Content/ContentImage/ContentImage.tsx
+++ b/src/components/Content/ContentImage/ContentImage.tsx
@@ -5,6 +5,7 @@ interface ContentImageProps {
   img: string;
   alt?: string;
   style?: React.CSSProperties;
+  className?: string;
   decorated?: boolean; // boxshadowをつけるかどうか
 }
 
@@ -12,10 +13,11 @@ export default function ContentImage({
   img,
   alt,
   style,
+  className,
   decorated = true,
 }: ContentImageProps) {
   return (
-    <div className={styles.contentImage} style={style}>
+    <div className={`${styles.contentImage} ${className}`} style={style}>
       {decorated ? (
         <DecoratedImage img={img} alt={alt} />
       ) : (

--- a/src/components/Content/ContentTitle/ContentTitle.tsx
+++ b/src/components/Content/ContentTitle/ContentTitle.tsx
@@ -7,6 +7,7 @@ interface ContentTitleProps {
   size: number;
   bigTitle?: boolean; // タイトルを横幅いっぱいに表示するかどうか
   style?: React.CSSProperties;
+  className?: string;
   animation?: AnimationType;
 }
 
@@ -15,6 +16,7 @@ export default function ContentTitle({
   size,
   bigTitle = false,
   style,
+  className,
   animation = "center",
 }: ContentTitleProps) {
   const HeadingTag = `h${size}` as keyof JSX.IntrinsicElements;
@@ -22,7 +24,7 @@ export default function ContentTitle({
   return (
     <Animation animationType={animation}>
       <HeadingTag
-        className={`${styles.contentTitle} ${styles.fontEffect} ${styles.retroShadow} ${bigTitle ? styles.bigTitle : ""}`}
+        className={`${styles.contentTitle} ${styles.fontEffect} ${styles.retroShadow} ${bigTitle ? styles.bigTitle : ""} ${className}`}
         style={style}
       >
         <span>{title}</span>

--- a/src/components/Content/DecoratedImage/DecoratedImage.tsx
+++ b/src/components/Content/DecoratedImage/DecoratedImage.tsx
@@ -4,16 +4,18 @@ interface DecoratedImageProps {
   img: string;
   alt?: string;
   style?: React.CSSProperties;
+  className?: string;
 }
 
 export default function DecoratedImage({
   img,
   alt,
   style,
+  className,
 }: DecoratedImageProps) {
   return (
     <img
-      className={styles.decoration}
+      className={`${styles.decoration} ${className}`}
       src={img}
       alt={alt || ""}
       style={style}

--- a/src/components/Content/PageWrapper/PageWrapper.tsx
+++ b/src/components/Content/PageWrapper/PageWrapper.tsx
@@ -3,12 +3,14 @@ import styles from "./PageWrapper.module.scss";
 export default function PageWrapper({
   children,
   style,
+  className,
 }: Readonly<{
   children: React.ReactNode;
   style?: React.CSSProperties;
+  className?: string;
 }>) {
   return (
-    <div className={styles.wrapper} style={style}>
+    <div className={`${styles.wrapper} ${className}`} style={style}>
       {children}
     </div>
   );

--- a/src/components/Content/SectionBody/SectionBody.tsx
+++ b/src/components/Content/SectionBody/SectionBody.tsx
@@ -3,12 +3,14 @@ import styles from "./SectionBody.module.scss";
 export default function SectionBody({
   children,
   style,
+  className,
 }: Readonly<{
   children: React.ReactNode;
   style?: React.CSSProperties;
+  className?: string;
 }>) {
   return (
-    <div className={styles.contentBlock} style={style}>
+    <div className={`${styles.contentBlock} ${className}`} style={style}>
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [Content系のコンポーネントのpropsにclassNameを追加する](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/290)

## 概要
<!-- 変更内容を簡単に説明 -->
Content系のコンポーネントのpropsにclassNameを追加して、コンポーネントを呼び出すところでstyleではなくclassNameでスタイルを当てられるように変更

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- Content系のコンポーネントのpropsにclassNameを追加
- ZIP-FMのナビゲーターの配置を修正
  |before|after|
  |-|-|
  |![image](https://github.com/user-attachments/assets/ec027413-a1a6-47af-8625-96c857aa9f80)|![image](https://github.com/user-attachments/assets/e8e83507-7611-4b51-89f1-ed8e13ca293e)|

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
