### PR TITLE
mainにoverflow-xが効いてない問題を修正

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -30,6 +30,7 @@ body {
 main {
   padding-top: calc(var(--main-padding-top));
   --main-padding-top: 60px;
+  overflow-x: hidden;
   @include phone {
     --main-padding-top: 50px;
   }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [`overflow-x: hidden`が効いてない](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/310)

## 概要
<!-- 変更内容を簡単に説明 -->
mainにoverflow-xが効いてないため横からのアニメーションがあると画面外にスクロールできてしまう問題を修正

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->
- mainに`overflow-x: hidden;`を追加

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->
企画ページ等の横からのアニメーションがあるページで確認

# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
