### PR TITLE
SNSアイコンリストにdisplay: flex;が当たっていない問題を修正

### DIFF
--- a/src/components/Sns/SnsIconList.tsx
+++ b/src/components/Sns/SnsIconList.tsx
@@ -6,8 +6,8 @@ import styles from "./SnsIconList.module.scss";
 
 export default function SnsIconList({ pcOnly }: { pcOnly?: boolean }) {
   return (
-    <div className={`${styles.snsIconList} ${pcOnly && styles.pcOnly}`}>
-      <Animation>
+    <Animation>
+      <div className={`${styles.snsIconList} ${pcOnly && styles.pcOnly}`}>
         <SnsIcon
           icon={BsTwitterX}
           color="#000000"
@@ -23,7 +23,7 @@ export default function SnsIconList({ pcOnly }: { pcOnly?: boolean }) {
           color="#FF0000"
           url="https://www.youtube.com/channel/UCplFRWLMUlNqYM081KZ7Juw"
         />
-      </Animation>
-    </div>
+      </div>
+    </Animation>
   );
 }


### PR DESCRIPTION
<!-- PRをmergeしたら自動でissueをcloseしたい場) -->
<!-- Closes [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

<!-- PRにissueをリンクだけしたい場合(自動でcloseはしない) -->
<!-- Related to [表示したい文字、issueタイトルがおすすめ](issueのURL) -->

Closes [スマホ表示でSNSアイコンが立て並びになっている](https://github.com/Nitech-Festival-Executive-Committee/koudaisai/issues/318)

## 概要
<!-- 変更内容を簡単に説明 -->
スマホ表示でSNSアイコンが立て並びになっている問題を修正
|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/a8fc2898-f823-4fa8-a2f0-40e980668c21)|![image](https://github.com/user-attachments/assets/111a2d4f-ea6c-44aa-b4dc-b4503f8b5a98)|

## 変更内容
<!-- 変更の概要と説明を記述 -->
<!-- 複数の方法で実装できる場合はどうしてその実装の仕方を選んだのかを書いておくとよい -->
<!-- UIが変わった場合など、必要があればスクリーンショットも添付 -->

## 確認方法
<!-- 必要があれば、確認するファイル名や変更の確認手順やテスト方法を記述 -->


# チェックリスト
- [ ] File Changedで不要な変更や誤った変更が無いか確認した
- [ ] 対応したissueをProjectの"レビュー中・待機中"に移動した
- [ ] レビューを頼んだ人にDiscordでお願いした
- [ ] 機密情報が含まれていないことを確認した(含まれている場合は直ちにリモートからコミットを削除すること)
- UIを変更した場合
  - [ ] PCで見た時に表示が崩れていないことを確認した
  - [ ] スマホでも正常に表示されることを確認した(大きい画面と小さい画面両方で)
- Web申請対応の場合
  - [ ] Web申請担当者に確認してもらった
